### PR TITLE
Error handling for TransformerError

### DIFF
--- a/app/birdbot.py
+++ b/app/birdbot.py
@@ -127,7 +127,7 @@ class BirdTree(app_commands.CommandTree):
         elif isinstance(error, app_commands.TransformerError):
             # Raised when a type annotation fails to convert to its target type.
             user_shown_error = errors.TransformerError(
-                content=f"Failed to convert {error.value} to {error.transformer._error_display_name}. Make sure member/channel/role exist."
+                content=f"Failed to convert {error.value} to {error.transformer._error_display_name}. Make sure member/channel/role exists."
             )
 
             embed = user_shown_error.format_notif_embed(interaction)

--- a/app/birdbot.py
+++ b/app/birdbot.py
@@ -123,6 +123,18 @@ class BirdTree(app_commands.CommandTree):
             await BirdTree.maybe_responded(interaction, embed=embed, ephemeral=True)
 
             return
+
+        elif isinstance(error, app_commands.TransformerError):
+            # Raised when a type annotation fails to convert to its target type.
+            user_shown_error = errors.TransformerError(
+                content=f"Failed to convert {error.value} to {error.transformer._error_display_name}. Make sure member/channel/role exist."
+            )
+
+            embed = user_shown_error.format_notif_embed(interaction)
+            await BirdTree.maybe_responded(interaction, embed=embed, ephemeral=True)
+
+            return
+
         elif isinstance(error, app_commands.CheckFailure):
             user_shown_error = errors.CheckFailure(content=str(error))
 

--- a/app/utils/errors.py
+++ b/app/utils/errors.py
@@ -86,3 +86,14 @@ class InvalidFunctionUsage(InternalError):
     """
 
     pass
+
+
+class TransformerError(InternalError, app_commands.TransformerError):
+    """
+    Error for discord type conversion.
+    """
+
+    title = "Conversion Error"
+    content = f"{InternalError.content}"
+
+    pass


### PR DESCRIPTION
<!--
!!!IMPORTANT!!!
We recommend you fill in as many fields as possible but we understand thats its not always viable 
You should REMOVE ALL UNUSED SECTIONS in this template before raising a request
-->
# Error handling for transformer error

## Description
Discordpy performs conversion when running an interaction. For example ID: `01234567890` will be converted to `some_member`. If the resource doesn't exist or type conversion fails, disord raises `app_commands.TransformerError`.
This change address the bot level error handling for `TransformerError` so as to send embed to command author.

## Checklist
<!-- Before submitting this pull request, make sure you've completed the following tasks and check the boxes that apply. -->

- [x] This PR makes changes to the code
    - [x] I have tested my changes locally and they work as expected.
    - [x] I have ensured that the code is free of linting errors and warnings.
    - [x] I have added any necessary comments or explanations to the code.
    - [x] I have updated the documentation (if applicable) to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)

## Additional Context
- Earlier:
<img width="687" alt="image" src="https://github.com/kurzgesagt-in-a-nutshell/birdbot/assets/30389481/57acb2f8-7a4f-4671-8c76-2133c058beff">

- After these changes:
<img width="615" alt="image" src="https://github.com/kurzgesagt-in-a-nutshell/birdbot/assets/30389481/65448df4-47b0-4ba1-bf60-d43c2f8a6d8a">

## Review Notes
Please review the error content message. Modify message content if necessary.